### PR TITLE
Set router and Vite base to root path

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,10 +55,8 @@ function AdminRoute({ children }) {
 
 
 function App() {
-    const basename = import.meta.env.PROD ? '/startrackerv2' : '';
-
     return (
-        <Router basename={basename}>
+    <Router>
             <ErrorBoundary>
                 <Routes>
                     {/* Public Routes */}

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,26 +3,23 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
-export default defineConfig(({ command }) => {
-    const base = command === 'build' ? '/startrackerv2/' : '/'
-
-    return {
-        plugins: [
-            react(),
-            tailwindcss(),
-        ],
-        base,
-        build: {
-            outDir: 'dist',
-            assetsDir: 'assets',
-            rollupOptions: {
-                output: {
-                    manualChunks: undefined,
-                },
+export default defineConfig(() => ({
+    plugins: [
+        react(),
+        tailwindcss(),
+    ],
+    // For custom domains, base should be '/'
+    base: '/',
+    build: {
+        outDir: 'dist',
+        assetsDir: 'assets',
+        rollupOptions: {
+            output: {
+                manualChunks: undefined,
             },
         },
-        server: {
-            open: true
-        }
+    },
+    server: {
+        open: true
     }
-})
+}))


### PR DESCRIPTION
Removed dynamic basename from React Router and set Vite's base config to '/'. This simplifies deployment, especially for custom domains, by ensuring all routes and assets resolve from the root.