### PR TITLE
Add custom domain to CNAME file

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+stjernekamp.aftersales.live


### PR DESCRIPTION
Configured the CNAME file to use stjernekamp.aftersales.live as the custom domain for deployment.