### PR TITLE
Update 404.html to handle custom domain routing

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -22,7 +22,8 @@
         // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
         // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
         // Otherwise, leave pathSegmentsToKeep as 0.
-        var pathSegmentsToKeep = 1;
+    // For custom domains (not project pages), keep 0 path segments
+    var pathSegmentsToKeep = 0;
 
         var l = window.location;
         l.replace(


### PR DESCRIPTION
Changed pathSegmentsToKeep from 1 to 0 to ensure correct redirect behavior for custom domains, improving 404 page handling outside of GitHub project pages.