### PR TITLE
Set Router basename to /startrackerv2

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -56,7 +56,7 @@ function AdminRoute({ children }) {
 
 function App() {
     return (
-    <Router>
+    <Router basename="/startrackerv2">
             <ErrorBoundary>
                 <Routes>
                     {/* Public Routes */}


### PR DESCRIPTION
Configured the React Router to use '/startrackerv2' as the base path. This ensures all routes are correctly prefixed when the app is deployed under this subdirectory.